### PR TITLE
Fix a bunch of compiler warnings, code cleanup

### DIFF
--- a/eurocrypt.c
+++ b/eurocrypt.c
@@ -16,6 +16,7 @@
 /* You should have received a copy of the GNU General Public License     */
 /* along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
+#include <assert.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -360,64 +361,76 @@ static void _eurocrypt(uint8_t *data, const uint8_t *key, int desmode, int emode
 		uint64_t r3;
 		uint8_t k2[8];
 		
-		/* EC-M */
-		if(emode == EC_M)
-		{
-			if(desmode == HASH)
-			{
-				_key_rotate_ec(&c, &d, ROTATE_LEFT, i);
-			}
-			
-			/* Key expansion */
-			_key_exp(&c, &d, k2);
-			
-			/* One DES round */
-			s = _ec_des_f(r, k2);
-			
-			if(desmode != HASH)
-			{
-				_key_rotate_ec(&c, &d, ROTATE_RIGHT, i);
-			}
-			
-			/* Swap first two bytes if it's a hash routine */
-			if(desmode == HASH)
-			{
-				s = ((s >> 8) & 0xFF0000L) | ((s << 8) & 0xFF000000L) | (s & 0x0000FFFFL);
-			}
-		}
-		
-		/* EC-S2 */
-		if(emode == EC_S)
-		{
-			/* Key rotation */
-			_key_rotate_ec(&c, &d, ROTATE_LEFT, i);
-			
-			/* Key expansion */
-			_key_exp(&c, &d, k2);
-			
-			/* One DES round */
-			s = _ec_des_f(r, k2);
-			
-		}
-		/* EC-3DES */
-		if(emode == EC_3DES)
-		{
-			/* Key rotation */
-			if(rnd != 2)
-			{
-				_key_rotate_ec(&c, &d, ROTATE_LEFT, i);
-			}
-			
-			/* Key expansion */
-			_key_exp(&c, &d, k2);
-			
-			/* One DES round */
-			s = _ec_des_f(r, k2);
-			
-			if(rnd == 2)
-			{
-				_key_rotate_ec(&c, &d, ROTATE_RIGHT, i);
-			}
+		switch (emode) {
+			/* If mode is not valid, abort -- this is a bug! */
+			default:
+				fprintf(stderr, "_eurocrypt: BUG: invalid encryption mode!!!\n");
+				assert(0);
+				break;
+
+			/* EC-M */
+			case EC_M:
+				{
+					if(desmode == HASH)
+					{
+						_key_rotate_ec(&c, &d, ROTATE_LEFT, i);
+					}
+					
+					/* Key expansion */
+					_key_exp(&c, &d, k2);
+					
+					/* One DES round */
+					s = _ec_des_f(r, k2);
+					
+					if(desmode != HASH)
+					{
+						_key_rotate_ec(&c, &d, ROTATE_RIGHT, i);
+					}
+					
+					/* Swap first two bytes if it's a hash routine */
+					if(desmode == HASH)
+					{
+						s = ((s >> 8) & 0xFF0000L) | ((s << 8) & 0xFF000000L) | (s & 0x0000FFFFL);
+					}
+				}
+				break;
+
+			/* EC-S2 */
+			case EC_S:
+				{
+					/* Key rotation */
+					_key_rotate_ec(&c, &d, ROTATE_LEFT, i);
+					
+					/* Key expansion */
+					_key_exp(&c, &d, k2);
+					
+					/* One DES round */
+					s = _ec_des_f(r, k2);
+					
+				}
+				break;
+
+			/* EC-3DES */
+			case EC_3DES:
+				{
+					/* Key rotation */
+					if(rnd != 2)
+					{
+						_key_rotate_ec(&c, &d, ROTATE_LEFT, i);
+					}
+					
+					/* Key expansion */
+					_key_exp(&c, &d, k2);
+					
+					/* One DES round */
+					s = _ec_des_f(r, k2);
+					
+					if(rnd == 2)
+					{
+						_key_rotate_ec(&c, &d, ROTATE_RIGHT, i);
+					}
+				}
+				break;
 		}
 		
 		/* Rotate halves around */

--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -564,7 +564,7 @@ static void *_input_thread(void *arg)
 					int max_bitmap_height = 0;
 					int bitmap_scale;
 					int x, y, pos, last_pos;
-					last_pos = 0;
+					last_pos = pos = 0;
 					
 					for(s = 0; s < sub.num_rects; s++)
 					{

--- a/videocrypt-ca.c
+++ b/videocrypt-ca.c
@@ -498,7 +498,7 @@ void _hash_ppv(uint64_t *answ, size_t len)
 	{
 		for (j = 1; j != len; j++) 
 		{
-			m = tab_1421[i] + answ[j - 1] & 0xFF;
+			m = (tab_1421[i] + answ[j - 1]) & 0xFF;
 			answ[j] = _rotate_left(answ[j] ^ moduli[m]);
 		}
 		answ[0] ^= answ[len-1];

--- a/videocrypt-ca.c
+++ b/videocrypt-ca.c
@@ -46,7 +46,7 @@ static uint8_t _crc(uint8_t *data)
 	return (~crc + 1);
 }
 
-static uint8_t _rotate_left(x)
+static uint8_t _rotate_left(uint8_t x)
 {
 	return (((x) << 1) | ((x) >> 7)) & 0xFF;
 }

--- a/videocrypt.c
+++ b/videocrypt.c
@@ -39,6 +39,7 @@
  * Marco Wabbel for xtea algo and Funcard (ATMEL based) hex files - needed for xtea.
 */
 
+#include <inttypes.h>
 #include <string.h>
 #include <math.h>
 #include "video.h"
@@ -551,7 +552,7 @@ int vc_render_line(vid_t *s, void *arg, int nlines, vid_line_t **lines)
 				fprintf(stderr, "\n\nVC1 ECM In:  ");
 				for(i = 0; i < 31; i++) fprintf(stderr, "%02X ", v->blocks[v->block].messages[strcmp(mode,"ppv") == 0 ? 0 : 5][i]);
 				fprintf(stderr,"\nVC1 ECM Out: ");
-				for(i = 0; i < 8; i++) fprintf(stderr, "%02llX ", v->cw >> (8 * i) & 0xFF);
+				for(i = 0; i < 8; i++) fprintf(stderr, "%02" PRIx64 " ", v->cw >> (8 * i) & 0xFF);
 				
 				if(s->conf.enableemm || s->conf.disableemm)
 				{
@@ -599,7 +600,7 @@ int vc_render_line(vid_t *s, void *arg, int nlines, vid_line_t **lines)
 				fprintf(stderr, "\n\nVC2 ECM In:  ");
 				for(i = 0; i < 31; i++) fprintf(stderr, "%02X ", v->blocks2[v->block2].messages[5][i]);
 				fprintf(stderr,"\nVC2 ECM Out: ");
-				for(i = 0; i < 8; i++) fprintf(stderr, "%02llX ", v->blocks2[v->block2].codeword >> (8 * i) & 0xFF);
+				for(i = 0; i < 8; i++) fprintf(stderr, "%02" PRIx64 " ", v->blocks2[v->block2].codeword >> (8 * i) & 0xFF);
 				
 				if(s->conf.enableemm || s->conf.disableemm)
 				{


### PR DESCRIPTION
Fixes a bunch of format-string and ambiguous-expression compiler warnings.
Clean up the Eurocrypt core function to use a case statement instead of a bunch of if statements.

Suggested future improvement -- put the Eurocrypt modes into an enum typedef.